### PR TITLE
Update standalone config to make it consistent with PR#1561

### DIFF
--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,6 +1,6 @@
 {
 	"ignoreGlobList": ["collated**"],
-	"ignoreCommitList":["15f4d36a4ed8e9fa2e40e13165c387bd94afeb02",
+	"ignoreCommitsList":["15f4d36a4ed8e9fa2e40e13165c387bd94afeb02",
 			    "385ad8a8a7f7e29c3605005f4727105421fb54e2",
 			    "626e998d89bc5ab158b35b00c1f86a1190c8e90d"],
 	"formats": ["java", "adoc", "md"],


### PR DESCRIPTION
[PR#1561](https://github.com/reposense/RepoSense/pull/1561) parses ```ignoreCommitsList``` instead of ```ignoreCommitList``` in Standalone Config.